### PR TITLE
fixes & formatting

### DIFF
--- a/copy_this/modules/ecomstyle.de/ecs_lowerurl/metadata.php
+++ b/copy_this/modules/ecomstyle.de/ecs_lowerurl/metadata.php
@@ -19,24 +19,24 @@
 
 $sMetadataVersion = '1.1';
 $aModule = array(
-    'id'            => 'ecs_lowerurl',
-    'title'         => '<strong style="color:#04B431;">e</strong><strong>ComStyle.de</strong>:  <i>LowerURL</i>',
-    'description'   => 'Gro&szlig;buchstaben in URL&acute;s werden in Kleinbuchstaben umgewandelt.<br>
+    'id'          => 'ecs_lowerurl',
+    'title'       => '<strong style="color:#04B431;">e</strong><strong>ComStyle.de</strong>:  <i>LowerURL</i>',
+    'description' => 'Gro&szlig;buchstaben in URL&acute;s werden in Kleinbuchstaben umgewandelt.<br>
                         <span style="color: #CC0000">Nach der Modulaktivierung unter Stammdaten/Grundeinstellungen/SEO auf den Button "SEO URLs neu berechnen" klicken!</span>
                         <br><iframe frameborder="no" width="600px" height="400px" src="https://ssl-account.com/incl.oxidtheme.de/gratis.html"></iframe>',
-    'thumbnail'     => 'ecs.png',
-    'version'       => '1.0',
-    'author'        => '<strong style="font-size: 17px;color:#04B431;">e</strong><strong style="font-size: 16px;">ComStyle.de</strong>',
-    'email'         => 'info@ecomstyle.de',
-    'url'           => 'http://ecomstyle.de',
-    'extend'        => array(
-	    'oxseoencoderarticle'       => 'ecomstyle.de/ecs_lowerurl/models/oxseoencoderarticlelowerurl',
-	    'oxseoencodercategory'      => 'ecomstyle.de/ecs_lowerurl/models/oxseoencodercategorylowerurl',
-	    'oxseoencodercontent'       => 'ecomstyle.de/ecs_lowerurl/models/oxseoencodercontentlowerurl',
-	    'oxseoencodermanufacturer'  => 'ecomstyle.de/ecs_lowerurl/models/oxseoencodermanufacturerlowerurl',
-	    'oxseoencodertag'           => 'ecomstyle.de/ecs_lowerurl/models/oxseoencodertaglowerurl',
-        'oxseoencoderrecomm'        => 'ecomstyle.de/ecs_lowerurl/models/oxseoencoderrecommlowerurl',
-        'oxseoencodervendor'        => 'ecomstyle.de/ecs_lowerurl/models/oxseoencodervendorlowerurl',
-    )
+    'thumbnail'   => 'ecs.png',
+    'version'     => '1.0',
+    'author'      => '<strong style="font-size: 17px;color:#04B431;">e</strong><strong style="font-size: 16px;">ComStyle.de</strong>',
+    'email'       => 'info@ecomstyle.de',
+    'url'         => 'http://ecomstyle.de',
+    'extend'      => array(
+        'oxseoencoderarticle'      => 'ecomstyle.de/ecs_lowerurl/models/oxseoencoderarticlelowerurl',
+        'oxseoencodercategory'     => 'ecomstyle.de/ecs_lowerurl/models/oxseoencodercategorylowerurl',
+        'oxseoencodercontent'      => 'ecomstyle.de/ecs_lowerurl/models/oxseoencodercontentlowerurl',
+        'oxseoencodermanufacturer' => 'ecomstyle.de/ecs_lowerurl/models/oxseoencodermanufacturerlowerurl',
+        'oxseoencodertag'          => 'ecomstyle.de/ecs_lowerurl/models/oxseoencodertaglowerurl',
+        'oxseoencoderrecomm'       => 'ecomstyle.de/ecs_lowerurl/models/oxseoencoderrecommlowerurl',
+        'oxseoencodervendor'       => 'ecomstyle.de/ecs_lowerurl/models/oxseoencodervendorlowerurl',
+    ),
 );
 ?>

--- a/copy_this/modules/ecomstyle.de/ecs_lowerurl/models/oxseoencoderarticlelowerurl.php
+++ b/copy_this/modules/ecomstyle.de/ecs_lowerurl/models/oxseoencoderarticlelowerurl.php
@@ -1,5 +1,4 @@
 <?php
-
 /*    Please retain this copyright header in all versions of the software
 *
 *    Copyright (C) 2015  Josef A. Puckl | eComStyle.de
@@ -17,12 +16,16 @@
 *    You should have received a copy of the GNU General Public License
 *    along with this program.  If not, see {http://www.gnu.org/licenses/}.
 */
-class oxseoencoderarticlelowerurl extends oxseoencoderarticlelowerurl_parent {
 
-	public function getArticleUrl($oArticle, $iLang = null, $iType = 0) {
-		$ret = parent::getArticleUrl($oArticle, $iLang = null, $iType = 0);
-		$sUri = strtolower($ret);
-		return $sUri;
-	}
+class oxseoencoderarticlelowerurl extends oxseoencoderarticlelowerurl_parent
+{
+
+    public function getArticleUrl($oArticle, $iLang = null, $iType = 0)
+    {
+        $ret = parent::getArticleUrl($oArticle, $iLang, $iType);
+        $sUri = strtolower($ret);
+
+        return $sUri;
+    }
 
 }

--- a/copy_this/modules/ecomstyle.de/ecs_lowerurl/models/oxseoencoderarticlelowerurl.php
+++ b/copy_this/modules/ecomstyle.de/ecs_lowerurl/models/oxseoencoderarticlelowerurl.php
@@ -1,4 +1,5 @@
 <?php
+
 /*    Please retain this copyright header in all versions of the software
 *
 *    Copyright (C) 2015  Josef A. Puckl | eComStyle.de
@@ -23,6 +24,22 @@ class oxseoencoderarticlelowerurl extends oxseoencoderarticlelowerurl_parent
     public function getArticleUrl($oArticle, $iLang = null, $iType = 0)
     {
         $ret = parent::getArticleUrl($oArticle, $iLang, $iType);
+        $sUri = strtolower($ret);
+
+        return $sUri;
+    }
+
+    /**
+     * return article main url, with path of its default category
+     *
+     * @param oxArticle $oArticle product
+     * @param int $iLang language id
+     *
+     * @return string
+     */
+    public function getArticleMainUrl($oArticle, $iLang = null)
+    {
+        $ret = parent::getArticleMainUrl($oArticle, $iLang);
         $sUri = strtolower($ret);
 
         return $sUri;

--- a/copy_this/modules/ecomstyle.de/ecs_lowerurl/models/oxseoencodercategorylowerurl.php
+++ b/copy_this/modules/ecomstyle.de/ecs_lowerurl/models/oxseoencodercategorylowerurl.php
@@ -1,5 +1,4 @@
 <?php
-
 /*    Please retain this copyright header in all versions of the software
 *
 *    Copyright (C) 2015  Josef A. Puckl | eComStyle.de
@@ -17,12 +16,33 @@
 *    You should have received a copy of the GNU General Public License
 *    along with this program.  If not, see {http://www.gnu.org/licenses/}.
 */
-class oxseoencodercategorylowerurl extends oxseoencodercategorylowerurl_parent {
 
-	public function getCategoryUrl($oCategory, $iLang = null) {
-		$ret = parent::getCategoryUrl($oCategory, $iLang = null);
-		$sUri = strtolower($ret);
-		return $sUri;
-	}
+class oxseoencodercategorylowerurl extends oxseoencodercategorylowerurl_parent
+{
+
+    public function getCategoryUrl($oCategory, $iLang = null)
+    {
+        $ret = parent::getCategoryUrl($oCategory, $iLang);
+        $sUri = strtolower($ret);
+
+        return $sUri;
+    }
+
+    /**
+     * Returns category lowercase SEO url for specified page
+     *
+     * @param oxcategory $oCategory category object
+     * @param int $iPage            page tu prepare number
+     * @param int $iLang            language
+     * @param bool $blFixed         fixed url marker (default is null)
+     *
+     * @return string
+     */
+    public function getCategoryPageUrl($oCategory, $iPage, $iLang = null, $blFixed = null)
+    {
+        $url = parent::getCategoryPageUrl($oCategory, $iPage, $iLang, $blFixed);
+
+        return strtolower($url);
+    }
 
 }

--- a/copy_this/modules/ecomstyle.de/ecs_lowerurl/models/oxseoencodercontentlowerurl.php
+++ b/copy_this/modules/ecomstyle.de/ecs_lowerurl/models/oxseoencodercontentlowerurl.php
@@ -1,5 +1,4 @@
 <?php
-
 /*    Please retain this copyright header in all versions of the software
 *
 *    Copyright (C) 2015  Josef A. Puckl | eComStyle.de
@@ -17,12 +16,16 @@
 *    You should have received a copy of the GNU General Public License
 *    along with this program.  If not, see {http://www.gnu.org/licenses/}.
 */
-class oxseoencodercontentlowerurl extends oxseoencodercontentlowerurl_parent {
 
-	public function getContentUrl($oCont, $iLang = null) {
-		$ret = parent::getContentUrl($oCont, $iLang = null);
-		$sUri = strtolower($ret);
-		return $sUri;
-	}
+class oxseoencodercontentlowerurl extends oxseoencodercontentlowerurl_parent
+{
+
+    public function getContentUrl($oCont, $iLang = null)
+    {
+        $ret = parent::getContentUrl($oCont, $iLang);
+        $sUri = strtolower($ret);
+
+        return $sUri;
+    }
 
 }

--- a/copy_this/modules/ecomstyle.de/ecs_lowerurl/models/oxseoencodermanufacturerlowerurl.php
+++ b/copy_this/modules/ecomstyle.de/ecs_lowerurl/models/oxseoencodermanufacturerlowerurl.php
@@ -1,5 +1,4 @@
 <?php
-
 /*    Please retain this copyright header in all versions of the software
 *
 *    Copyright (C) 2015  Josef A. Puckl | eComStyle.de
@@ -17,12 +16,16 @@
 *    You should have received a copy of the GNU General Public License
 *    along with this program.  If not, see {http://www.gnu.org/licenses/}.
 */
-class oxseoencodermanufacturerlowerurl extends oxseoencodermanufacturerlowerurl_parent {
 
-	public function getManufacturerUrl($oManufacturer, $iLang = null) {
-		$ret = parent::getManufacturerUrl($oManufacturer, $iLang = null);
-		$sUri = strtolower($ret);
-		return $sUri;
-	}
+class oxseoencodermanufacturerlowerurl extends oxseoencodermanufacturerlowerurl_parent
+{
+
+    public function getManufacturerUrl($oManufacturer, $iLang = null)
+    {
+        $ret = parent::getManufacturerUrl($oManufacturer, $iLang);
+        $sUri = strtolower($ret);
+
+        return $sUri;
+    }
 
 }

--- a/copy_this/modules/ecomstyle.de/ecs_lowerurl/models/oxseoencoderrecommlowerurl.php
+++ b/copy_this/modules/ecomstyle.de/ecs_lowerurl/models/oxseoencoderrecommlowerurl.php
@@ -1,5 +1,4 @@
 <?php
-
 /*    Please retain this copyright header in all versions of the software
 *
 *    Copyright (C) 2015  Josef A. Puckl | eComStyle.de
@@ -17,12 +16,16 @@
 *    You should have received a copy of the GNU General Public License
 *    along with this program.  If not, see {http://www.gnu.org/licenses/}.
 */
-class oxseoencoderrecommlowerurl extends oxseoencoderrecommlowerurl_parent {
 
-	public function getRecommUrl($oRecomm, $iLang = null) {
-		$ret = parent::getRecommUrl($oRecomm, $iLang = null);
-		$sUri = strtolower($ret);
-		return $sUri;
-	}
+class oxseoencoderrecommlowerurl extends oxseoencoderrecommlowerurl_parent
+{
+
+    public function getRecommUrl($oRecomm, $iLang = null)
+    {
+        $ret = parent::getRecommUrl($oRecomm, $iLang);
+        $sUri = strtolower($ret);
+
+        return $sUri;
+    }
 
 }

--- a/copy_this/modules/ecomstyle.de/ecs_lowerurl/models/oxseoencodertaglowerurl.php
+++ b/copy_this/modules/ecomstyle.de/ecs_lowerurl/models/oxseoencodertaglowerurl.php
@@ -1,5 +1,4 @@
 <?php
-
 /*    Please retain this copyright header in all versions of the software
 *
 *    Copyright (C) 2015  Josef A. Puckl | eComStyle.de
@@ -17,12 +16,16 @@
 *    You should have received a copy of the GNU General Public License
 *    along with this program.  If not, see {http://www.gnu.org/licenses/}.
 */
-class oxseoencodertaglowerurl extends oxseoencodertaglowerurl_parent {
 
-	public function getTagUrl($sTag, $iLang = null) {
-		$ret = parent::getTagUrl($sTag, $iLang = null);
-		$sUri = strtolower($ret);
-		return $sUri;
-	}
+class oxseoencodertaglowerurl extends oxseoencodertaglowerurl_parent
+{
+
+    public function getTagUrl($sTag, $iLang = null)
+    {
+        $ret = parent::getTagUrl($sTag, $iLang);
+        $sUri = strtolower($ret);
+
+        return $sUri;
+    }
 
 }

--- a/copy_this/modules/ecomstyle.de/ecs_lowerurl/models/oxseoencodervendorlowerurl.php
+++ b/copy_this/modules/ecomstyle.de/ecs_lowerurl/models/oxseoencodervendorlowerurl.php
@@ -1,5 +1,4 @@
 <?php
-
 /*    Please retain this copyright header in all versions of the software
 *
 *    Copyright (C) 2015  Josef A. Puckl | eComStyle.de
@@ -17,12 +16,16 @@
 *    You should have received a copy of the GNU General Public License
 *    along with this program.  If not, see {http://www.gnu.org/licenses/}.
 */
-class oxseoencodervendorlowerurl extends oxseoencodervendorlowerurl_parent {
 
-	public function getVendorUrl($oVendor, $iLang = null) {
-		$ret = parent::getVendorUrl($oVendor, $iLang = null);
-		$sUri = strtolower($ret);
-		return $sUri;
-	}
+class oxseoencodervendorlowerurl extends oxseoencodervendorlowerurl_parent
+{
+
+    public function getVendorUrl($oVendor, $iLang = null)
+    {
+        $ret = parent::getVendorUrl($oVendor, $iLang);
+        $sUri = strtolower($ret);
+
+        return $sUri;
+    }
 
 }

--- a/copy_this/modules/ecomstyle.de/vendormetadata.php
+++ b/copy_this/modules/ecomstyle.de/vendormetadata.php
@@ -8,4 +8,4 @@
  *      All rights reserved - Alle Rechte vorbehalten
  *   *********************************************************************************************
  */
- $sVendorMetadataVersion = '1.0';
+$sVendorMetadataVersion = '1.0';


### PR DESCRIPTION
1. fix for category paging urls:
   override getCategoryPageUrl in oxseoencodercategorylowerurl.php to cover paging urls like category/2
2. fix for params: dont set them to null in parent call like 
   parent::getCategoryUrl($oCategory, $iLang);
   vs
   parent::getCategoryUrl($oCategory, $iLang = null);
   (might solve the language bug, ich hab gerade keinen multilanguage shop zum testen)
3. formatting as in oxid core:
   space instead of tabs
